### PR TITLE
Implemented SMOTE for dataset balancing before train-test split

### DIFF
--- a/detection.ipynb
+++ b/detection.ipynb
@@ -564,9 +564,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sklearn.model_selection import train_test_split\n",
+    "smote = SMOTE(random_state=42)\n",
+    "X_res, y_res = smote.fit_resample(features, target)\n",
     "\n",
-    "X_train, X_test, y_train, y_test = train_test_split(features, target, test_size=0.2, random_state=42)"
+    "# Split the dataset into training and testing sets\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X_res, y_res, test_size=0.2, random_state=42)"
    ]
   },
   {


### PR DESCRIPTION
I have implemented  SMOTE (Synthetic Minority Oversampling technique) before splitting the dataset to create a more balanced training set and reduce overfitting to the majority class.